### PR TITLE
Allows binding list to interfaces

### DIFF
--- a/extensions/listBinding/impl/ListBinding.cs
+++ b/extensions/listBinding/impl/ListBinding.cs
@@ -49,10 +49,18 @@ namespace strange.extensions.listBind.impl
 
         public new IInjectionBinding To<T>()
         {
-            var binding = injectionBinder.Bind(ListItemType).To<T>().ToName(typeof(T).ToString());
+            IInjectionBinding binding;
+            if (typeof (T).IsInterface)
+            {
+                binding = injectionBinder.GetBinding<T>();
+            }
+            else
+            {
+                binding = injectionBinder.Bind(ListItemType).To<T>().ToName(typeof(T).ToString());
+            }
+            
             bindings.Add(binding);
             return binding;
-
         }
 
         public IInjectionBinding ToValue(object o)


### PR DESCRIPTION
Hi,

I recommend the following change. This allows the ability to bind list to interface types which have been previously bound.

for example:

injectionBinder.Bind<ICat>.To<Cat>.InSingletonScope();
injectionBinder.Bind<IDog>.To<Dog>.InSingletonScope();
listBinder.Bind<IAnimal>.To<ICat>();
listBinder.Bind<IAnimal>.To<IDog>();

something like this, and when you ask for a list of IAnimal you should get the same Cat and Dog every time that are bound to ICat and IDog.
